### PR TITLE
simpleServer.py fix to be able to start and to pass response delay time

### DIFF
--- a/Python/simpleServer.py
+++ b/Python/simpleServer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
  
 import SimpleHTTPServer, BaseHTTPServer, SocketServer, socket, time, sys
+from SimpleHTTPServer import SimpleHTTPRequestHandler
  
 class ThreadedHTTPServer(SocketServer.ThreadingMixIn,
                          BaseHTTPServer.HTTPServer) :
@@ -12,7 +13,7 @@ class ThreadedHTTPServer(SocketServer.ThreadingMixIn,
     """
     def setDelay(self):
         try:
-            delay = sys.argv[2]
+            delay = float(sys.argv[2])
         except IndexError:
             delay = 0.0
         return delay


### PR DESCRIPTION
In my case I had to modify your script to be able to run it on Python 2.6.9

1. The "from SimpleHTTPServer import SimpleHTTPRequestHandler"
Otherwise I get a 'AttributeError: 'module' object has no Attribute 'SimpleHTTPRequestHandler'

2. While giving both command line Options, the delay time gets a "TypeError: a float is required"
That's why I do a float() around